### PR TITLE
PG-1321 Remove percona-telemetry-agent as a hard dependency of percona_pg_telemetry package

### DIFF
--- a/percona-packaging/debian/changelog
+++ b/percona-packaging/debian/changelog
@@ -1,3 +1,14 @@
+percona-pg-telemetry (1.2.1-1) unstable; urgency=medium
+
+  * Drop hard dependency on percona-telemetry-agent. The extension has been a
+    no-op stub since 1.2.0 and no longer writes to /usr/local/percona/telemetry/pg,
+    so the agent, the percona-telemetry group, and the drop directory are no
+    longer required.
+  * Drop postinst/postrm management of /usr/local/percona/telemetry/pg and of
+    postgres group membership in percona-telemetry.
+
+ -- Surabhi Bhat <surabhi.bhat@percona.com>  Tue, 21 Jul 2026 13:47:00 +0530
+
 percona-pg-telemetry (1.0.0-1) unstable; urgency=medium
 
   * Initial build.

--- a/percona-packaging/debian/control
+++ b/percona-packaging/debian/control
@@ -9,7 +9,6 @@ Build-Depends:
 Package: percona-pg-telemetryPGVERSION
 Architecture: any
 Depends:
- percona-telemetry-agent,
  ${misc:Depends},
  ${shlibs:Depends},
 Description:The percona_pg_telemetry is an extension for Percona telemetry data collection for PostgreSQL.

--- a/percona-packaging/debian/control.in
+++ b/percona-packaging/debian/control.in
@@ -9,7 +9,6 @@ Build-Depends:
 Package: percona-pg-telemetryPGVERSION
 Architecture: any
 Depends:
- percona-telemetry-agent,
  ${misc:Depends},
  ${shlibs:Depends},
 Description:The percona_pg_telemetry is an extension for Percona telemetry data collection for PostgreSQL.

--- a/percona-packaging/debian/postinst
+++ b/percona-packaging/debian/postinst
@@ -1,12 +1,11 @@
 #!/bin/sh
 
 #DEBHELPER#
-usermod -a -G percona-telemetry postgres
 
-mkdir /usr/local/percona/telemetry/pg
-chown postgres:percona-telemetry /usr/local/percona/telemetry/pg
-chmod 775 /usr/local/percona/telemetry/pg
-chmod g+s /usr/local/percona/telemetry/pg
-chmod u+s /usr/local/percona/telemetry/pg
+# Transitional cleanup: percona-pg-telemetry <= 1.1 managed this dir for the
+# telemetry-agent. The extension no longer uses it. Remove in a future release.
+if [ -d /usr/local/percona/telemetry/pg ] && [ -z "$(ls -A /usr/local/percona/telemetry/pg 2>/dev/null)" ]; then
+    rmdir /usr/local/percona/telemetry/pg 2>/dev/null || true
+fi
+
 exit 0
-

--- a/percona-packaging/debian/postrm
+++ b/percona-packaging/debian/postrm
@@ -22,15 +22,8 @@ fi
 
 case "$1" in
 	remove | purge)
-	set -e
-        PG_TELEMETRY=/usr/local/percona/telemetry/pg
-        if [ -d ${PG_TELEMETRY} ];
-        then
-                rm -rf ${PG_TELEMETRY}
-        fi
-
-	set +e
-
+	# The extension no longer owns /usr/local/percona/telemetry/pg.
+	# Leftover empty dirs from <= 1.1 are cleaned in postinst.
 	;;
 
 	upgrade | failed-upgrade | abort-install | abort-upgrade | disappear)

--- a/percona-packaging/rpm/pg-percona-telemetry.spec
+++ b/percona-packaging/rpm/pg-percona-telemetry.spec
@@ -11,7 +11,6 @@ License:        PostgreSQL
 Source0:        percona-pg-telemetry%{pgrel}-%{version}.tar.gz
 URL:            https://github.com/percona/percona_pg_telemetry
 BuildRequires:  percona-postgresql%{pgrel}-devel
-Requires:       percona-telemetry-agent
 Provides:       percona-pg-telemetry%{pgrel}
 Conflicts:      percona-pg-telemetry%{pgrel}
 Obsoletes:      percona-pg-telemetry%{pgrel} <= %{version}-%{release}
@@ -51,11 +50,12 @@ if [ $1 == 1 ]; then
 fi
 
 %post -n percona-pg-telemetry%{pgrel}
-usermod -a -G percona-telemetry postgres
-install -d -m 2775 -o postgres -g percona-telemetry /usr/local/percona/telemetry/pg
-
-%postun -n percona-pg-telemetry%{pgrel}
-rm -rf /usr/local/percona/telemetry/pg
+# Transitional cleanup: percona-pg-telemetry <= 1.1 managed this dir for the
+# telemetry-agent. The extension no longer uses it. Remove in a future release.
+if [ -d /usr/local/percona/telemetry/pg ] && [ -z "$(ls -A /usr/local/percona/telemetry/pg 2>/dev/null)" ]; then
+    rmdir /usr/local/percona/telemetry/pg 2>/dev/null || :
+fi
+exit 0
 
 %files
 %defattr(755,root,root,755)
@@ -68,5 +68,12 @@ rm -rf /usr/local/percona/telemetry/pg
 
 
 %changelog
+* Tue Jul 21 2026 Surabhi Bhat <surabhi.bhat@percona.com> - 1.2.1-1
+- Drop hard dependency on percona-telemetry-agent. The extension has been a
+  no-op stub since 1.2.0 and no longer writes to /usr/local/percona/telemetry/pg,
+  so the agent, the percona-telemetry group, and the drop directory are no
+  longer required.
+- Drop %post/%postun management of /usr/local/percona/telemetry/pg and of
+  postgres group membership in percona-telemetry.
 * Fri Apr 26 2024 Surabhi Bhat <surabhi.bhat@percona.com> - 1.0.0-1
 - Initial build


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PG-1321

Remove percona-telemetry-agent entirely as a run-time dependency of percona-pg-telemetry package. We are however shipping an empty shell for telemetry and no data is being sent, hence it doesn’t make sense to install the percona-telemetry-agent package as a dependency for PG.
Also, drop %post/%postun management of /usr/local/percona/telemetry/pg and of postgres group membership in percona-telemetry.