### PR TITLE
Update packaging script and changelog

### DIFF
--- a/percona-packaging/debian/changelog
+++ b/percona-packaging/debian/changelog
@@ -1,4 +1,4 @@
-percona-pg-telemetry (1.2.1-1) unstable; urgency=medium
+percona-pg-telemetry (1.2.0-3) unstable; urgency=medium
 
   * Drop hard dependency on percona-telemetry-agent. The extension has been a
     no-op stub since 1.2.0 and no longer writes to /usr/local/percona/telemetry/pg,

--- a/percona-packaging/rpm/pg-percona-telemetry.spec
+++ b/percona-packaging/rpm/pg-percona-telemetry.spec
@@ -68,7 +68,7 @@ exit 0
 
 
 %changelog
-* Tue Jul 21 2026 Surabhi Bhat <surabhi.bhat@percona.com> - 1.2.1-1
+* Tue Jul 21 2026 Surabhi Bhat <surabhi.bhat@percona.com> - 1.2.0-3
 - Drop hard dependency on percona-telemetry-agent. The extension has been a
   no-op stub since 1.2.0 and no longer writes to /usr/local/percona/telemetry/pg,
   so the agent, the percona-telemetry group, and the drop directory are no

--- a/percona-packaging/scripts/pg_percona_telemetry_builder.sh
+++ b/percona-packaging/scripts/pg_percona_telemetry_builder.sh
@@ -206,22 +206,12 @@ install_deps() {
         yum install -y https://repo.percona.com/yum/percona-release-latest.noarch.rpm
         percona-release enable ${PPG_REPO} testing
 
-        yum -y install git wget
+        yum -y install git wget llvm-devel clang-devel clang
         PKGLIST="percona-postgresql${PG_RELEASE}-devel"
 	if [ x"$RHEL" = x8 ]; then
             yum -y install python2-devel
-	    llvm_version=$(yum list --showduplicates llvm-devel | grep "17.0" | grep llvm | awk '{print $2}' | head -n 1)
-	    yum -y install llvm-devel-${llvm_version}
         else
-            yum -y install python-devel llvm-devel
-        fi
-        if [ x"$RHEL" = x8 ];
-        then
-	    clang_version=$(yum list --showduplicates clang-devel | grep "17.0" | grep clang | awk '{print $2}' | head -n 1)
-            yum install -y clang-devel-${clang_version} clang-${clang_version}
-            dnf module -y disable llvm-toolset
-        else
-            yum install -y clang-devel clang
+            yum -y install python-devel
         fi
         PKGLIST+=" git rpmdevtools vim wget"
         PKGLIST+=" perl binutils gcc gcc-c++"


### PR DESCRIPTION
Install default llvm-devel and clang on OL8 instead of pinning LLVM 17. This matches the LLVM major used by percona-postgresql-devel
Update version to 1.2.0-3 in changelog